### PR TITLE
Adding weather command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module golly-bot
 go 1.19
 
 require (
+	github.com/briandowns/openweathermap v0.19.0 // indirect
 	github.com/bwmarrin/discordgo v0.26.1 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
 	github.com/joho/godotenv v1.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/briandowns/openweathermap v0.19.0 h1:nkopLMEtZLxbZI1th6dOG6xkajpszofqf53r5K8mT9k=
+github.com/briandowns/openweathermap v0.19.0/go.mod h1:0GLnknqicWxXnGi1IqoOaZIw+kIe5hkt+YM5WY3j8+0=
 github.com/bwmarrin/discordgo v0.26.1 h1:AIrM+g3cl+iYBr4yBxCBp9tD9jR3K7upEjl0d89FRkE=
 github.com/bwmarrin/discordgo v0.26.1/go.mod h1:NJZpH+1AfhIcyQsPeuBKsUtYrRnjkyu0kIVMCHkZtRY=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=

--- a/main.go
+++ b/main.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/discordgo"
+	owm "github.com/briandowns/openweathermap"
 )
 
 var (
@@ -163,6 +164,19 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 					return
 				}
 			}
+		case botPrefix + "weather":
+			var apiKey = "your apikey here"
+			w, err := owm.NewCurrent("F", "EN", apiKey) // Returns weather in fahrenheit and English
+			if err != nil {
+				log.Fatalln(err)
+			}
+			var location = strings.Title(strings.ToLower(strings.SplitN(m.Content, " ", 2)[1]))
+			w.CurrentByName(location)
+			var result = fmt.Sprintf("Feels Like: %.2f°F\nTemperature: %.2f°F\nMin Temperature: %.2f°F\nMax Temperature: %.2f°F\nHumidity: %d%%\nWind speed: %.2fm/s\n", w.Main.FeelsLike, w.Main.Temp, w.Main.TempMin, w.Main.TempMax, w.Main.Humidity, w.Wind.Speed)
+			for _, item := range w.Weather {
+				result += fmt.Sprintf("%s: %s\n", item.Main, item.Description)
+			}
+			s.ChannelMessageSend(m.ChannelID, result)
 		}
 		// if the message doesn't start with the prefix, then we check if it matches
 		// one of the predefined messages to respond too

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ var (
 
 var (
 	token     = "your token here"
+	aptly     = "openweather apiKey"
 	botPrefix = "!"
 	buffer    = make([][]byte, 0)
 
@@ -165,8 +166,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 				}
 			}
 		case botPrefix + "weather":
-			var apiKey = "your apikey here"
-			w, err := owm.NewCurrent("F", "EN", apiKey) // Returns weather in fahrenheit and English
+			w, err := owm.NewCurrent("F", "EN", aptly) // Returns weather in fahrenheit and English
 			if err != nil {
 				log.Fatalln(err)
 			}


### PR DESCRIPTION
[Issue](https://github.com/ACM-VIT/golly-bot/issues/20)

Created a command `!weather <location_city>,<location_country>`, and the bot replies with weather information for that location using  [OpenWeatherMap GO API](https://github.com/briandowns/openweathermap). Returns weather in English and Fahrenheit. To use the OpenweatherMap API, you need to obtain an API key. Sign up [here](http://home.openweathermap.org/users/sign_up) and insert it in the code where indicated.

![image](https://user-images.githubusercontent.com/37389654/194774662-b1a05955-94d1-4be0-848f-d57f60d5216b.png)
