### PR TITLE
update logging system to log slash commands

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,6 +52,7 @@ var (
 					Content: "<t:" + strconv.FormatInt(time.Now().Unix(), 10) + ">",
 				},
 			})
+			logCommand(s, i.GuildID, i.Member.User.Username, "time")
 		},
 	}
 )
@@ -164,6 +165,29 @@ func main() {
 	dg.Close()
 }
 
+func logCommand(s *discordgo.Session, gID, user, command string) {
+	// Add slash prefix to the log if given command is a slash command
+	// Else add prefix as BotPrefix
+	var prefix = "Slash"
+	if strings.Contains(command, botPrefix) {
+		prefix = "BotPrefix"
+	}
+
+	// Log commands in the channel
+	if logChannelID != "" {
+		guild, err := s.Guild(gID)
+		if err != nil {
+			fmt.Printf("Error getting guild info: %s", err)
+			return
+		}
+
+		s.ChannelMessageSend(
+			logChannelID,
+			fmt.Sprintf(`[%s] %s > %s > %s`, prefix, guild.Name, user, command),
+		)
+	}
+}
+
 // Sets the maximum number of messages to track for a session
 func trackSessionMessages(dg *discordgo.Session) {
 	dg.State.MaxMessageCount = 10000
@@ -262,20 +286,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			fmt.Println("Command not implemented")
 			return
 		}
-
-		// Log commands in the channel
-		if logChannelID != "" {
-			guild, err := s.Guild(m.GuildID)
-			if err != nil {
-				fmt.Printf("Error getting guild info: %s", err)
-				return
-			}
-
-			s.ChannelMessageSend(
-				logChannelID,
-				fmt.Sprintf(`%s > %s > %s`, guild.Name, m.Author.Username, m.Content),
-			)
-		}
+		logCommand(s, m.GuildID, m.Author.Username, m.Content)
 
 		// if the message doesn't start with the prefix, then we check if it matches
 		// one of the predefined messages to respond too

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ var (
 					Content: "<t:" + strconv.FormatInt(time.Now().Unix(), 10) + ">",
 				},
 			})
-			logCommand(s, i.GuildID, i.Member.User.Username, "time")
+			logCommand(s, i.GuildID, "time", i.Member.User)
 		},
 	}
 )
@@ -165,7 +165,7 @@ func main() {
 	dg.Close()
 }
 
-func logCommand(s *discordgo.Session, gID, user, command string) {
+func logCommand(s *discordgo.Session, gID, command string, user *discordgo.User) {
 	// Add slash prefix to the log if given command is a slash command
 	// Else add prefix as BotPrefix
 	var prefix = "Slash"
@@ -286,7 +286,7 @@ func messageCreate(s *discordgo.Session, m *discordgo.MessageCreate) {
 			fmt.Println("Command not implemented")
 			return
 		}
-		logCommand(s, m.GuildID, m.Author.Username, m.Content)
+		logCommand(s, m.GuildID, m.Content, m.Author)
 
 		// if the message doesn't start with the prefix, then we check if it matches
 		// one of the predefined messages to respond too


### PR DESCRIPTION
Improved the logging system to log slash commands and add prefix to the log based on the command (either bot prefix or slash).

Slash command log:
<img width="435" alt="image" src="https://user-images.githubusercontent.com/77732328/195759784-f2ac34de-dbab-41aa-a253-104706877f21.png">

Command with bot prefix:
<img width="466" alt="image" src="https://user-images.githubusercontent.com/77732328/195759865-7ae0a6da-8ad0-459f-bd99-83779f0e285a.png">

Closes #53 