### PR TITLE
Modify Dockerfile to support different go files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.19.2-alpine3.16                                                                  
+ENV RUNFILE=main.go
 WORKDIR /golly-bot                                                                                                       
 COPY . .                                                                                                                
-ENTRYPOINT ["go","run","main.go"]  
+ENTRYPOINT ["/bin/sh", "-c", "go run ${RUNFILE}"]  

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ A general purpose Discord bot, written in GO!
   * To specify command line arguments, use
     <pre><code>docker run -it &lt;your image name&gt; &lt;arguments&gt;</pre></code> 
     For example:<pre><code>docker run -it &lt;your image name&gt; -rmcmd=false</pre></code>
+  * To run a different go file at entry point use
+    <pre><code>docker run -it -e RUNFILE=voice.go &lt;your image name&gt; &lt;arguments&gt;</code></pre>
   
 <!-- ---
 ## Overview


### PR DESCRIPTION
solves #78 by introducing environment parameter **RUNFILE** to set a file to be run by go.